### PR TITLE
Adds more information about embedded YAML in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 CLI tool for loading markdown files into a SQLite database.
 
 YAML embedded in the markdown files will be used to populate additional columns.
+See the [pandoc documentation](https://pandoc.org/MANUAL.html#metadata-variables)
+for more information. Only caveat is that the embedded YAML has to be
+terminated with `---` instead.
 
     Usage: markdown-to-sqlite [OPTIONS] DBNAME TABLE PATHS...
 


### PR DESCRIPTION
After the discussion in https://github.com/simonw/markdown-to-sqlite/issues/5
I figured it could be useful for other people to have that information
directly into the readme.
